### PR TITLE
Used monolog formatter (if available) in MonologHandler

### DIFF
--- a/src/IncomingsMonologHandler.php
+++ b/src/IncomingsMonologHandler.php
@@ -39,6 +39,13 @@ class IncomingsMonologHandler extends AbstractProcessingHandler
     protected function send($data)
     {
         $level = strtolower($data['level_name']);
-        $this->incomings->$level($data['message']);
+
+        if ($this->getFormatter()) {
+            return $this->incomings->$level(
+                $this->getFormatter()->format($data)
+            );
+        }
+
+        return $this->incomings->$level($data['message']);
     }
 }


### PR DESCRIPTION
This enables the apps to use custom log formatters when needed (https://laravel.com/docs/5.6/logging#advanced-monolog-channel-customization).

For example, for a Fargate application that is called by multiple apps and environments, it's good to have the caller app and also the environment in the log message.